### PR TITLE
Add 2 Dockerfiles for MOFED 5.3

### DIFF
--- a/Dockerfile.centos7.9.mofed-5.3
+++ b/Dockerfile.centos7.9.mofed-5.3
@@ -1,0 +1,14 @@
+FROM centos:7.9.2009
+RUN yum install -y perl numactl-libs gtk2 atk cairo gcc-gfortran tcsh libnl3 tcl tk python-devel pciutils make lsof redhat-rpm-config rpm-build libxml2-python ethtool iproute net-tools openssh-clients git openssh-server wget libusbx fuse-libs
+
+WORKDIR /tmp/
+
+RUN git clone https://github.com/esnet/iperf.git && cd iperf && ./configure --bindir=/usr/bin/ && make -j 8 && make install
+
+ENV MOFED_VER 5.3-1.0.0.1
+ENV OS_VER rhel7.9
+ENV PLATFORM x86_64
+
+RUN wget http://content.mellanox.com/ofed/MLNX_OFED-${MOFED_VER}/MLNX_OFED_LINUX-${MOFED_VER}-${OS_VER}-${PLATFORM}.tgz && \
+        tar -xvf MLNX_OFED_LINUX-${MOFED_VER}-${OS_VER}-${PLATFORM}.tgz && \
+        MLNX_OFED_LINUX-${MOFED_VER}-${OS_VER}-${PLATFORM}/mlnxofedinstall --user-space-only --without-fw-update --all --force

--- a/Dockerfile.ubuntu16.04.mofed-4.4
+++ b/Dockerfile.ubuntu16.04.mofed-4.4
@@ -1,0 +1,30 @@
+#Currently this Dockerfile is supported on building on Ubuntu only.
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+	perl \
+	tcsh tcl tk pciutils make lsof \
+	lsb-release \
+	libnuma1 \
+	python-libxml2 \
+	ethtool iproute net-tools \
+	openssh-server \
+	wget git \
+	pkg-config bison dpatch libgfortran3 \
+	kmod linux-headers-4.4.0-92-generic libnl-route-3-200 \
+	swig libelf1 automake libglib2.0-0 \
+	autoconf graphviz chrpath flex libnl-3-200 m4 \
+	debhelper autotools-dev gfortran libltdl-dev
+RUN apt install -y ca-certificates
+
+WORKDIR /tmp/
+
+RUN git clone https://github.com/esnet/iperf.git && cd iperf && ./configure --bindir=/usr/bin/ && make -j 8 && make install
+
+ENV MOFED_VER 4.4-1.0.0.0
+ENV OS_VER ubuntu16.04
+ENV PLATFORM x86_64
+
+RUN wget --quiet http://content.mellanox.com/ofed/MLNX_OFED-${MOFED_VER}/MLNX_OFED_LINUX-${MOFED_VER}-${OS_VER}-${PLATFORM}.tgz && \
+        tar -xvf MLNX_OFED_LINUX-${MOFED_VER}-${OS_VER}-${PLATFORM}.tgz && \
+        MLNX_OFED_LINUX-${MOFED_VER}-${OS_VER}-${PLATFORM}/mlnxofedinstall --user-space-only --without-fw-update --all --force

--- a/Dockerfile.ubuntu18.04.mofed-5.3
+++ b/Dockerfile.ubuntu18.04.mofed-5.3
@@ -1,0 +1,33 @@
+#Currently this Dockerfile is supported on building on Ubuntu only.
+FROM ubuntu:18.04
+
+# avoiding interactively select the geographic area
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+	perl \
+	tcsh tcl tk pciutils make lsof \
+	lsb-release \
+	libnuma1 \
+	python-libxml2 \
+	ethtool iproute2 net-tools \
+	openssh-server \
+	wget git \
+	pkg-config bison dpatch libgfortran3 \
+	kmod libnl-route-3-200 \
+	swig libelf1 automake libglib2.0-0 \
+	autoconf graphviz chrpath flex libnl-3-200 m4 \
+	debhelper autotools-dev gfortran libltdl-dev
+RUN apt install -y ca-certificates
+
+WORKDIR /tmp/
+
+RUN git clone https://github.com/esnet/iperf.git && cd iperf && ./configure --bindir=/usr/bin/ && make -j 8 && make install
+
+ENV MOFED_VER 5.3-1.0.0.1
+ENV OS_VER ubuntu18.04
+ENV PLATFORM x86_64
+
+RUN wget --quiet http://content.mellanox.com/ofed/MLNX_OFED-${MOFED_VER}/MLNX_OFED_LINUX-${MOFED_VER}-${OS_VER}-${PLATFORM}.tgz && \
+        tar -xvf MLNX_OFED_LINUX-${MOFED_VER}-${OS_VER}-${PLATFORM}.tgz && \
+        MLNX_OFED_LINUX-${MOFED_VER}-${OS_VER}-${PLATFORM}/mlnxofedinstall --user-space-only --without-fw-update --all --force


### PR DESCRIPTION
Also rename 'ubuntu16.4' to 'ubuntu 16.04' in filename.

Both new Dockerfiles built smoothly on x86_64 CentOS 7.8.2003 with docker 19.03.15, and pushed as `poanpan/mlnx_ofed_linux-5.3-1.0.0.1-centos7.9` and `poanpan/mlnx_ofed_linux-5.3-1.0.0.1-ubuntu18.04`.